### PR TITLE
Convert all arguments to float

### DIFF
--- a/floatrange.py
+++ b/floatrange.py
@@ -40,7 +40,7 @@ def frange(start, stop, step=1):
         The function works with floating point numbers. stop is never included
         in the range. Step size is 1 by default.
     """
-    a, b, s = start, stop, step
+    a, b, s = float(start), float(stop), float(step)
     x = (b - a) / s
     if x == 0:
         return asarray([])

--- a/floatrange.py
+++ b/floatrange.py
@@ -50,4 +50,7 @@ def frange(start, stop, step=1):
         if (D * b - D * a) / r / D == s:
             A, n, d, N = D * a, T, D, r
         N = int(N) - 1  # due to subtle difference from Julia
-    return asarray([(A + k * n) / d for k in range(0, N + 1)])
+    ret = asarray([(A + k * n) / d for k in range(0, N + 1)])
+    if N >= 0:
+        ret[0] = start  # ensure start is contained exactly
+    return ret

--- a/test_floatrange.py
+++ b/test_floatrange.py
@@ -73,3 +73,7 @@ def test_frange():
 
 def test_frange_includes_start():
     assert frange(110.0, 120.0, 10/60*5)[0] == 110.0
+
+
+def test_frange_int_float_equality():
+    assert all(frange(110, 120.0, 1/6*5) == frange(110.0, 120.0, 1/6*5))

--- a/test_floatrange.py
+++ b/test_floatrange.py
@@ -28,6 +28,7 @@ def test_frange_new(start, step, stop, length):
     assert len(r) == length
     if len(r) > 0:
         all(r == a)
+        assert r[0] == start/10
 
 
 # testsuite from https://github.com/JuliaLang/julia/pull/5636/files
@@ -68,3 +69,7 @@ def test_frange():
                                                     prevfloat(0.2)])
     assert all(frange(0.0, 0.3, nextfloat(0.1)) == [0.0, nextfloat(0.1),
                                                     nextfloat(0.2)])
+
+
+def test_frange_includes_start():
+    assert frange(110.0, 120.0, 10/60*5)[0] == 110.0


### PR DESCRIPTION
For some arguments, changing the type from int to an equal float changed the result slightly. As this might be surprising, in this PR, all arguments are converted to float to avoid this inconsistency.